### PR TITLE
removed `#![feature(generic_associated_types)]` since GATs are stable in 1.65

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2018"
 
 description = "Generic Map trait"
 
-repository = "https://github.com/Perseus101/map-trait"
-
 readme = "README.md"
 
 keywords = ["map", "data-structure", "generic", "containers"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "map-trait"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Colin Moore <colin@moore.one>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Map Trait
-A trait for a generic Map
+A trait for a generic Map. This is a fork from [Perseus101/map-trait](https://github.com/Perseus101/map-trait)
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,2 @@
-#![allow(incomplete_features)]
-#![feature(generic_associated_types)]
-
 pub mod map;
 pub mod set;

--- a/src/map.rs
+++ b/src/map.rs
@@ -10,8 +10,6 @@ use std::ops::Deref;
 /// most recent key and value to be inserted. Because the LastInsertMap implements
 /// Map, it can be seamlessly used as a replacement for other maps.
 /// ```
-/// #![allow(incomplete_features)]
-/// #![feature(generic_associated_types)]
 /// use std::borrow::Borrow;
 /// use std::hash::Hash;
 /// use std::collections::HashMap;
@@ -49,7 +47,7 @@ use std::ops::Deref;
 ///     V: 'm + Copy,
 ///     M: Map<'m, K, V>,
 /// {
-///     type GetGuard<'a> where 'm: 'a = M::GetGuard<'a>;
+///     type GetGuard<'a> = M::GetGuard<'a> where Self: 'a;
 ///
 ///     #[inline]
 ///     fn get<'a, Q: ?Sized>(&'a self, k: &Q) -> Option<Self::GetGuard<'a>>
@@ -78,7 +76,9 @@ use std::ops::Deref;
 /// # }
 /// ```
 pub trait Map<'m, K, V: 'm> {
-    type GetGuard<'a>: Deref<Target = V> where 'm: 'a;
+    type GetGuard<'a>: Deref<Target = V>
+    where
+        Self: 'a;
 
     fn get<'a, Q: ?Sized>(&'a self, k: &Q) -> Option<Self::GetGuard<'a>>
     where
@@ -93,7 +93,7 @@ where
     V: 'm,
     S: std::hash::BuildHasher,
 {
-    type GetGuard<'a> where 'm: 'a = &'a V;
+    type GetGuard<'a> = &'a V where Self: 'a;
 
     #[inline]
     fn get<'a, Q: ?Sized>(&'a self, k: &Q) -> Option<Self::GetGuard<'a>>
@@ -115,7 +115,7 @@ where
     K: Ord,
     V: 'm,
 {
-    type GetGuard<'a> where 'm: 'a = &'a V;
+    type GetGuard<'a> = &'a V where Self: 'a;
 
     #[inline]
     fn get<'a, Q: ?Sized>(&'a self, k: &Q) -> Option<Self::GetGuard<'a>>

--- a/src/set.rs
+++ b/src/set.rs
@@ -9,8 +9,6 @@ use std::hash::Hash;
 /// most recent value to be inserted. Because the LastInsertSet implements
 /// Set, it can be seamlessly used as a replacement for other sets.
 /// ```
-/// #![allow(incomplete_features)]
-/// #![feature(generic_associated_types)]
 /// use std::borrow::Borrow;
 /// use std::hash::Hash;
 /// use std::collections::HashSet;
@@ -86,12 +84,11 @@ where
     T: Hash + Eq,
     S: std::hash::BuildHasher,
 {
-
     #[inline]
     fn contains<Q: ?Sized>(&self, value: &Q) -> bool
     where
         T: Borrow<Q>,
-        Q: Hash + Eq + Ord
+        Q: Hash + Eq + Ord,
     {
         std::collections::HashSet::contains(self, value)
     }
@@ -106,12 +103,11 @@ impl<T> Set<T> for std::collections::BTreeSet<T>
 where
     T: Ord,
 {
-
     #[inline]
     fn contains<Q: ?Sized>(&self, value: &Q) -> bool
     where
         T: Borrow<Q>,
-        Q: Hash + Eq + Ord
+        Q: Hash + Eq + Ord,
     {
         std::collections::BTreeSet::contains(self, value)
     }


### PR DESCRIPTION
The title says it all